### PR TITLE
Changes normal to normal! before matching (%) to avoid unexpected mappings

### DIFF
--- a/indent/java.vim
+++ b/indent/java.vim
@@ -119,7 +119,7 @@ function GetJavaIndent()
   " skipping over "throws", "extends" and "implements" clauses.
   if getline(v:lnum) =~ '^\s*}\s*\(//.*\|/\*.*\)\=$'
     call cursor(v:lnum, 1)
-    silent normal %
+    silent normal! %
     let lnum = line('.')
     if lnum < v:lnum
       while lnum > 1


### PR DESCRIPTION
When editing java with the matchit plugin in terminal vim, I was seeing a delay when closing a block with the `}` character on its own line - I'd hit escape, but the escape would be swallowed and my subsequent keystrokes would be inserted into the buffer. This only happened with `}` on its own line, and only in java source files. With some help from bairui in the #vim channel on freenode, I was able to narrow it down to the block dealing with `}`s on their own line, and bairui specifically suggested changing `silent normal %` to `silent normal! %` instead of just commenting out the whole block, which also worked for my purposes.

I don't know if anyone else is having this problem, but it worked for me and allowed me to not get rid of the matchit plugin.
