### PR TITLE
Don't require annotation lines to match non-whitespace until end of line

### DIFF
--- a/indent/java.vim
+++ b/indent/java.vim
@@ -73,7 +73,7 @@ function GetJavaIndent()
 
   " If the previous line starts with '@', we should have the same indent as
   " the previous one
-  if getline(lnum) =~ '^\s*@\S\+\s*$'
+  if getline(lnum) =~ '^\s*@.*$'
     return indent(lnum)
   endif
 


### PR DESCRIPTION
The previous version would not match annotations that have any whitespace
and then non-whitespace after them, e.g. `@whatever /* comment about @whatever */`
