### PR TITLE
Fixed indentation of throws

### DIFF
--- a/indent/java.vim
+++ b/indent/java.vim
@@ -88,8 +88,8 @@ function GetJavaIndent()
 
   " Try to align "throws" lines for methods and "extends" and "implements" for
   " classes.
-  if getline(v:lnum) =~ '^\s*\(extends\|implements\)\>'
-        \ && getline(lnum) !~ '^\s*\(extends\|implements\)\>'
+  if getline(v:lnum) =~ '^\s*\(throws\|extends\|implements\)\>'
+        \ && getline(lnum) !~ '^\s*\(throws\|extends\|implements\)\>'
     let theIndent = theIndent + &sw
   endif
 


### PR DESCRIPTION
Hi,

I always wondered, why the lines starting with throws are never indented, until I had a look into the regexes where the throws is simply missing :)

This PR fixes that bug.

Cheers
 -Fritz